### PR TITLE
More explicit date format

### DIFF
--- a/dingdong.js
+++ b/dingdong.js
@@ -26,7 +26,9 @@
       element.style.color = ''
       element.style.fontWeight = ''
     }
-    element.textContent = date.toLocaleDateString([], { dateStyle: 'full' })
+    var reformattedDate = date.toLocaleDateString([],
+      {weekday: 'long', month: 'long', day: 'numeric', year: 'numeric'})
+    element.textContent = reformattedDate
   }
 
   function quickEdit () {


### PR DESCRIPTION
Surprisingly, `dateStyle` was not stable across environments.  In my
browser,

  (new Date()).toLocaleDateString('en', { style: 'full' })
  "2/1/2021"

  (new Date()).toLocaleDateString('de', { dateStyle: 'full' })
  "1.2.2021"

I've switched to a full list of date component options, which should
behave more similarly everywhere.

Closes #2